### PR TITLE
Add support for headless in recent (> ~109) chrome versions

### DIFF
--- a/doc/chrome.md
+++ b/doc/chrome.md
@@ -17,6 +17,24 @@ reference of the available startup options.
 (def foreground-chrome (chrome/launch {:headless false}))
 ```
 
+### Old and new headless
+
+Since version 96, Chrome has a new headless mode that allows users to get the
+full browser functionality (even run extensions). Between versions 96 to 108 it was
+--headless=chrome, after version 109 --headless=new. `cuic` supports both old and new
+headless modes.
+
+```clojure
+;; launch in old headless mode
+(def old-headless-chrome (chrome/launch {:headless "old"}))
+
+;; deprecated: equivalent with {:headless "old"} but may be removed in future
+(def old-headless-chrome (chrome/launch {:headless true}))
+
+;; launch in new headless mode
+(def new-headless-chrome (chrome/launch {:headless "new"}))
+```
+
 If you're using a non-standard Chrome/Chromium installation, you can
 provide the executable path as a parameter to the `launch` invocation:
 

--- a/src/clj/cuic/core.clj
+++ b/src/clj/cuic/core.clj
@@ -168,7 +168,7 @@
 (defn sleep
   "Stops the current thread execution for the given
    `n` milliseconds."
-  [ms]
+  [^long ms]
   {:pre [(nat-int? ms)]}
   (Thread/sleep ms))
 

--- a/src/clj/cuic/internal/input.clj
+++ b/src/clj/cuic/internal/input.clj
@@ -83,5 +83,5 @@
       (type-char cdt ch)
       (when xs
         (when (pos-int? chars-per-minute)
-          (Thread/sleep (/ 60000 chars-per-minute)))
+          (Thread/sleep ^long (/ 60000 chars-per-minute)))
         (recur xs)))))


### PR DESCRIPTION
## problem

I recently ran into some problems when running tests with `cuic` in headless mode. In particular I started getting `Could not detect Chrome tabs` exceptions.

This seems to be caused by chromium doing a breaking change recently (version ~109). When started headless,
it seems it has "zero" tabs open, which causes `cuic` to crash in `chrome/launch`.

## solution

This can be fixed by providing an url and `about:blank` is short and failsafe way to provide one. Chromium also recently released 'new' headless mode (https://developer.chrome.com/articles/new-headless/), which seems to also fix this issue.
I decided ***not*** to make it the new default because `playwright` team found it up to 50% slower in some cases.

## After this PR

- `cuic` works in headless mode with chrome versions > 109
- `cuic` supports 'new' headless (https://developer.chrome.com/articles/new-headless/)
- 'old' headless is still used by default since this way we avoid breaking changes +
  `playwright` developers had noticed ~30-50% performance hit with 'new' headless.
  see: https://github.com/microsoft/playwright/issues/21216
- (chrome/launch) :headless parameter now supports these values:
    - false -> same as before
    - true  -> gets translated to 'old'
    - old   -> runs chrome in --headless=old
    - new   -> runs chrome in --headless=new

I did a not very scientific performance experiment via `time`, which suggest that in `cuic` case there seems to be only minimal performance difference between old and new headless modes.

Using old headless

<img width="781" alt="Screenshot 2023-05-19 at 10 06 52" src="https://github.com/milankinen/cuic/assets/61139818/c1409f2c-e2cb-4ed4-931e-8fbf3ffa7213">

Using new headless

<img width="781" alt="Screenshot 2023-05-19 at 10 22 28" src="https://github.com/milankinen/cuic/assets/61139818/cc6e9bcf-3d9e-41d7-a710-ade34b805cbd">