### PR TITLE
Allow passing chrome binary path via environment variable

### DIFF
--- a/src/clj/cuic/chrome.clj
+++ b/src/clj/cuic/chrome.clj
@@ -22,7 +22,8 @@
 (set! *warn-on-reflection* true)
 
 (defn- get-chrome-binary-path ^Path []
-  (or (->> ["/usr/bin/chromium",
+  (or (->> [(System/getenv "CHROME_BINARY_PATH"),
+            "/usr/bin/chromium",
             "/usr/bin/chromium-browser",
             "/usr/bin/google-chrome-stable",
             "/usr/bin/google-chrome",


### PR DESCRIPTION
I've been exploring cuic on NixOS, which doesn't adhere to the standard file system hierarchy, making the hard-coded paths in `cuic.chrome` problematic. This PR introduces the ability to specify the path to the Chrome binary using an environment variable.

This feature isn't just beneficial for NixOS users. Allowing users to point to a specific Chrome binary can be useful for testing against upcoming, unreleased versions of Chrome or pinning a specific version for consistent testing (e.g., using the Nix package manager on MacOS).